### PR TITLE
Enable text backgrounds with corner radius

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ This will generate an `outputs/feature-examples.png` file showcasing all the ava
                 *   `border`: Object containing border properties for the mask. Optional.
                     *   `color`: The color of the border. Optional, default is '#000000'.
                     *   `size`: The size of the border in pixels. Optional, default is 5.
-            *   `background`: The background color to use behind the masked image. Optional.
+                *   `background`, `backgroundColor`, or `background-color`: Background color to place behind the masked image. Optional.
+            *   `background`: Background color can also be specified at the element level. Optional.
             
             If type is `text`, the element will be a text and have the following properties:
             *   `text`: The text to display. Can include HTML tags like `<br>` for line breaks.
@@ -70,6 +71,9 @@ This will generate an `outputs/feature-examples.png` file showcasing all the ava
             *   `fontSize`: The size of the font.
             *   `color`: The color of the text.
             *   `rotation`: The rotation of the text.
+            *   `background`, `backgroundColor`, or `background-color`: Background color behind the text. Optional.
+            *   `backgroundCornerRadius` or `background-corner-radius`: Corner radius for the background. Optional.
+            *   Backgrounds include a small internal margin and span all text lines, including those created with `<br>`.
             *   `shadow`: Object containing shadow properties. Optional.
                 *   `color`: The color of the shadow. Optional, default is 'black'.
                 *   `offsetX`: The horizontal offset of the shadow in pixels. Optional, default is 2.

--- a/invoke.mjs
+++ b/invoke.mjs
@@ -27,9 +27,9 @@ const event = {
                     "border": {
                         "color": "#3498db",
                         "size": 5
-                    }
-                },
-                "background": "#000"
+                    },
+                    "background-color": "#000"
+                }
             },
             {
                 "id": "name",
@@ -47,7 +47,9 @@ const event = {
                     "offsetX": 2,
                     "offsetY": 2,
                     "blur": 4
-                }
+                },
+                "background-color": "#ffff99",
+                "backgroundCornerRadius": 15
             }
         ]
     }

--- a/invoke_examples.mjs
+++ b/invoke_examples.mjs
@@ -335,6 +335,20 @@ const event = {
                     "offsetY": 2,
                     "blur": 3
                 }
+            },
+            {
+                "id": "bg-text-example",
+                "type": "text",
+                "text": "Background<br>Text",
+                "fontFamily": "sans-serif",
+                "fontSize": "40px",
+                "fontWeight": "bold",
+                "color": "#333333",
+                "origin": "center",
+                "x": 0,
+                "y": 650,
+                "background-color": "#ffff99",
+                "backgroundCornerRadius": 20
             }
         ]
     }

--- a/tests/test_text_background.js
+++ b/tests/test_text_background.js
@@ -1,0 +1,45 @@
+import { handler } from '../index.mjs';
+import fs from 'fs';
+
+const event = {
+  shouldReturnAsBase64: true,
+  generator: 'generic',
+  region: 'eu-west-3',
+  outName: 'tests/text-bg.png',
+  params: {
+    imageWidth: 400,
+    imageHeight: 200,
+    background: null,
+    defaultBackground: { r: 255, g: 255, b: 255, alpha: 1 },
+    elements: [
+      {
+        id: 'text-bg',
+        type: 'text',
+        text: 'Hello World',
+        fontFamily: 'sans-serif',
+        fontSize: '40px',
+        fontWeight: 'bold',
+        color: '#333333',
+        origin: 'center',
+        x: 0,
+        y: 0,
+        'background-color': '#ffff99',
+        backgroundCornerRadius: 20
+      }
+    ]
+  }
+};
+
+(async () => {
+  try {
+    const result = await handler(event);
+    if (result.statusCode === 200 && result.isBase64Encoded) {
+      fs.writeFileSync('./outputs/test_text_background.png', Buffer.from(result.body, 'base64'));
+      console.log('Text background test image saved as ./outputs/test_text_background.png');
+    } else {
+      console.error('Text background test failed:', result);
+    }
+  } catch (err) {
+    console.error('Error running text background test:', err);
+  }
+})();


### PR DESCRIPTION
## Summary
- support a background rectangle behind text
- configure text background color and corner radius
- document text background options in README
- show text background usage in invocation examples
- add test script for text background
- refine text background alignment and padding

## Testing
- `node invoke.mjs`
- `node tests/test_mask_background.js`
- `node tests/test_text_background.js`


------
https://chatgpt.com/codex/tasks/task_e_685313fe3d20832581393b4900c8ba8d