### PR TITLE
Add per-side padding and corner radius for text backgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ This will generate an `outputs/feature-examples.png` file showcasing all the ava
             *   `color`: The color of the text.
             *   `rotation`: The rotation of the text.
             *   `background`, `backgroundColor`, or `background-color`: Background color behind the text. Optional.
-            *   `backgroundCornerRadius` or `background-corner-radius`: Corner radius for the background. Optional.
-            *   `backgroundPadding` or `background-padding`: Internal padding around the text when a background is used. Optional, default is 6 pixels.
+            *   `backgroundCornerRadius` or `background-corner-radius`: Corner radius for the background. Accepts a single number or CSS-style values to control each corner individually.
+            *   `backgroundPadding` or `background-padding`: Internal padding around the text when a background is used. Accepts a single number or CSS-style values for top/right/bottom/left. Optional, default is 6 pixels.
             *   Backgrounds include a small internal margin and span all text lines, including those created with `<br>`.
             *   `shadow`: Object containing shadow properties. Optional.
                 *   `color`: The color of the shadow. Optional, default is 'black'.

--- a/tests/test_text_background_per_side.js
+++ b/tests/test_text_background_per_side.js
@@ -1,0 +1,46 @@
+import { handler } from '../index.mjs';
+import fs from 'fs';
+
+const event = {
+  shouldReturnAsBase64: true,
+  generator: 'generic',
+  region: 'eu-west-3',
+  outName: 'tests/text-bg-per-side.png',
+  params: {
+    imageWidth: 400,
+    imageHeight: 200,
+    background: null,
+    defaultBackground: { r: 255, g: 255, b: 255, alpha: 1 },
+    elements: [
+      {
+        id: 'text-bg',
+        type: 'text',
+        text: 'Corners',
+        fontFamily: 'sans-serif',
+        fontSize: '40px',
+        fontWeight: 'bold',
+        color: '#333333',
+        origin: 'center',
+        x: 0,
+        y: 0,
+        background: '#ccffcc',
+        backgroundCornerRadius: '10 20 30 40',
+        backgroundPadding: { top: 10, right: 20, bottom: 5, left: 15 }
+      }
+    ]
+  }
+};
+
+(async () => {
+  try {
+    const result = await handler(event);
+    if (result.statusCode === 200 && result.isBase64Encoded) {
+      fs.writeFileSync('./outputs/test_text_background_per_side.png', Buffer.from(result.body, 'base64'));
+      console.log('Advanced text background test saved as ./outputs/test_text_background_per_side.png');
+    } else {
+      console.error('Advanced text background test failed:', result);
+    }
+  } catch (err) {
+    console.error('Error running advanced text background test:', err);
+  }
+})();


### PR DESCRIPTION
## Summary
- allow specifying text background padding and corner radius per side
- document new CSS style syntax in README
- add an example test demonstrating the feature

## Testing
- `node tests/test_text_background.js`
- `node tests/test_text_background_per_side.js`


------
https://chatgpt.com/codex/tasks/task_e_6854547880fc8325814877b14e445aa5